### PR TITLE
update dsrc drivers channels

### DIFF
--- a/dsrc_driver/config/wave.json
+++ b/dsrc_driver/config/wave.json
@@ -3,7 +3,7 @@
     "name" : "BSM",
     "psid" : "0020",
     "dsrc_id" : "20",
-    "channel" : "172",
+    "channel" : "183",
     "priority" :  "6"
   },
   {
@@ -17,77 +17,77 @@
     "name" : "MAP",
     "psid" : "0082",
     "dsrc_id" : "18",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "3"
   },
   {
     "name" : "SPAT",
     "psid" : "0082",
     "dsrc_id" : "19",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "3"
   },
   {
     "name" : "MobilityRequest",
     "psid" : "BFEE",
     "dsrc_id" : "240",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "6"
   },
   {
     "name" : "MobilityResponse",
     "psid" : "BFEE",
     "dsrc_id" : "241",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "6"
   },
   {
     "name" : "MobilityOperation",
     "psid" : "BFEE",
     "dsrc_id" : "243",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "6"
   },
   {
     "name" : "MobilityPath",
     "psid" : "BFEE",
     "dsrc_id" : "242",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "6"
   },
   {
     "name" : "TrafficControlRequest",
     "psid" : "8003",
     "dsrc_id" : "244",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "6"
   },
   {
     "name" : "PSM",
     "psid" : "0082",
     "dsrc_id" : "32",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "6"
   },
   {
     "name" : "TrafficControlMessage",
     "psid" : "8003",
     "dsrc_id" : "245",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "6"
   },
   {
     "name" : "EmergencyVehicleResponse",
     "psid" : "8005",
     "dsrc_id" : "246",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "6"
   },
   {
     "name" : "EmergencyVehicleAck",
     "psid" : "8005",
     "dsrc_id" : "247",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "6"
   }
 ]

--- a/dsrc_driver/etc/wave.json
+++ b/dsrc_driver/etc/wave.json
@@ -3,7 +3,7 @@
     "name" : "BSM",
     "psid" : "0020",
     "dsrc_id" : "20",
-    "channel" : "172",
+    "channel" : "183",
     "priority" :  "6"
   },
   {
@@ -17,77 +17,77 @@
     "name" : "MAP",
     "psid" : "0082",
     "dsrc_id" : "18",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "3"
   },
   {
     "name" : "SPAT",
     "psid" : "0082",
     "dsrc_id" : "19",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "3"
   },
   {
     "name" : "MobilityRequest",
     "psid" : "BFEE",
     "dsrc_id" : "240",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "6"
   },
   {
     "name" : "MobilityResponse",
     "psid" : "BFEE",
     "dsrc_id" : "241",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "6"
   },
   {
     "name" : "MobilityOperation",
     "psid" : "BFEE",
     "dsrc_id" : "243",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "6"
   },
   {
     "name" : "MobilityPath",
     "psid" : "BFEE",
     "dsrc_id" : "242",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "6"
   },
   {
     "name" : "TrafficControlRequest",
     "psid" : "8003",
     "dsrc_id" : "244",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "6"
   },
   {
     "name" : "PSM",
     "psid" : "0082",
     "dsrc_id" : "32",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "6"
   },
   {
     "name" : "TrafficControlMessage",
     "psid" : "8003",
     "dsrc_id" : "245",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "6"
   },
   {
     "name" : "EmergencyVehicleResponse",
     "psid" : "8005",
     "dsrc_id" : "246",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "6"
   },
   {
     "name" : "EmergencyVehicleAck",
     "psid" : "8005",
     "dsrc_id" : "247",
-    "channel" : "172",
+    "channel" : "183",
     "priority" : "6"
   }
 ]


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

The channels in wave.json file are updated to reflect the upgrade to the new CV2X radios/

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

https://usdot-carma.atlassian.net/browse/CDAD-57
## Motivation and Context

The new CV2X radios are configured on a new channel.

## How Has This Been Tested?
Integration tested during TRB demo (Jan 2024) on Blue Lexus, Black Pacifica and Ford Fusion
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
