### PR TITLE
Add optional flag to manage lifecycle transitions during launch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,10 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 ARG DOCKER_ORG="usdotfhwastoldev"
-ARG DOCKER_TAG="develop"
+ARG DOCKER_TAG="develop-humble"
 FROM ${DOCKER_ORG}/carma-base:${DOCKER_TAG} as base_image
 FROM base_image as setup
-ARG GIT_BRANCH="develop"
+ARG GIT_BRANCH="develop-humble"
 
 ARG ROS1_PACKAGES=""
 ENV ROS1_PACKAGES=${ROS1_PACKAGES}

--- a/v2x_ros_driver/launch/v2x_ros_driver.launch.py
+++ b/v2x_ros_driver/launch/v2x_ros_driver.launch.py
@@ -13,7 +13,7 @@
 # the License.
 
 from ament_index_python import get_package_share_directory
-from launch import LaunchDescription
+from launch import LaunchDescription, LaunchContext
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 from launch.actions import DeclareLaunchArgument
@@ -24,6 +24,7 @@ import launch.events
 import launch_ros.events.lifecycle
 import lifecycle_msgs.msg
 from carma_ros2_utils.launch.get_current_namespace import GetCurrentNamespace
+from launch.actions import ExecuteProcess, OpaqueFunction
 
 import os
 
@@ -32,6 +33,45 @@ import os
 This file is can be used to launch the CARMA v2x_ros_driver_node.
   Though in carma-platform it may be launched directly from the base launch file.
 '''
+
+def launch_v2x_lifecycle(context: LaunchContext, enable_v2x_lifecycle_arg, configuration_delay_arg):
+
+    # Get enable_v2x_lifecycle launch argument
+    enable_v2x_lifecycle = context.perform_substitution(enable_v2x_lifecycle_arg)
+
+    # Check if the lifecycle should be enabled
+    if enable_v2x_lifecycle == 'true':
+        # Get the ROS2 executable
+        ros2_cmd = context.perform_substitution( launch.substitutions.FindExecutable(name='ros2'))
+
+        # Configuration delay
+        configuration_delay = context.perform_substitution(configuration_delay_arg)
+
+        # Process configuration
+        process_configure = ExecuteProcess(
+            cmd=[ros2_cmd, "lifecycle", "set", "/v2x_ros_driver_node", "configure"],
+        )
+
+        # Timer action
+        configuration_trigger = launch.actions.TimerAction(
+            period=float(configuration_delay),
+            actions=[process_configure]
+        )
+
+        # Event handler for activation
+        configured_event_handler = launch.actions.RegisterEventHandler(
+            launch.event_handlers.OnExecutionComplete(
+                target_action=process_configure,
+                on_completion=[
+                    launch.actions.ExecuteProcess(
+                        cmd=[ros2_cmd, "lifecycle", "set", "/v2x_ros_driver_node", "activate"],
+                    )
+                ]
+            )
+        )
+
+        return [ configuration_trigger, configured_event_handler]
+    return []
 
 def generate_launch_description():
 
@@ -42,7 +82,11 @@ def generate_launch_description():
 
     configuration_delay = LaunchConfiguration('configuration_delay')
     declare_configuration_delay_arg = DeclareLaunchArgument(
-        name ='configuration_delay', default_value='4.0')
+        name ='configuration_delay', default_value='2.0')
+
+    enable_v2x_lifecycle = LaunchConfiguration('enable_v2x_lifecycle')
+    declare_enable_v2x_lifecycle = DeclareLaunchArgument(
+        name ='enable_v2x_lifecycle', default_value='true')
 
     # Get parameter file path
     param_file_path = os.path.join(
@@ -76,32 +120,11 @@ def generate_launch_description():
         on_exit= Shutdown()
     )
 
-    ros2_cmd = launch.substitutions.FindExecutable(name='ros2')
-
-    process_configure = launch.actions.ExecuteProcess(
-        cmd=[ros2_cmd, "lifecycle", "set", "/v2x_ros_driver", "configure"],
-    )
-
-    configuration_trigger = launch.actions.TimerAction(
-        period=configuration_delay,
-        actions=[
-            process_configure,
-        ]
-    )
-
-    configured_event_handler = launch.actions.RegisterEventHandler(launch.event_handlers.OnExecutionComplete(
-        target_action=process_configure, on_completion=[
-            launch.actions.ExecuteProcess(
-                cmd=[ros2_cmd, "lifecycle", "set", "/v2x_ros_driver", "activate"],
-            )
-        ])
-    )
-
 
     return LaunchDescription([
         declare_log_level_arg,
         declare_configuration_delay_arg,
+        declare_enable_v2x_lifecycle,
         container,
-        configuration_trigger,
-        configured_event_handler
+        OpaqueFunction(function=launch_v2x_lifecycle, args=[enable_v2x_lifecycle, configuration_delay]),
     ])

--- a/v2x_ros_driver/launch/v2x_ros_driver.launch.py
+++ b/v2x_ros_driver/launch/v2x_ros_driver.launch.py
@@ -23,6 +23,8 @@ from launch_ros.descriptions import ComposableNode
 from launch.actions import DeclareLaunchArgument, Shutdown, ExecuteProcess, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from carma_ros2_utils.launch.get_current_namespace import GetCurrentNamespace
+from launch.conditions import IfCondition
+from launch.substitutions import PythonExpression
 
 import os
 
@@ -31,50 +33,6 @@ import os
 This file is can be used to launch the CARMA v2x_ros_driver_node.
   Though in carma-platform it may be launched directly from the base launch file.
 '''
-
-'''
-This function is used to call the v2x_ros_driver_node lifecycle transitions.
-  It will configure the node and then activate it.
-'''
-def transition_v2x_driver_lifecycle(context: LaunchContext, enable_v2x_driver_lifecycle_arg, configuration_delay_arg):
-
-    # Get enable_v2x_driver_lifecycle launch argument
-    enable_v2x_driver_lifecycle = context.perform_substitution(enable_v2x_driver_lifecycle_arg)
-
-    # Check if the lifecycle should be enabled
-    if enable_v2x_driver_lifecycle == 'true':
-        # Get the ROS2 executable
-        ros2_cmd = context.perform_substitution( launch.substitutions.FindExecutable(name='ros2'))
-
-        # Configuration delay
-        configuration_delay = context.perform_substitution(configuration_delay_arg)
-
-        # Process configuration
-        process_configure = ExecuteProcess(
-            cmd=[ros2_cmd, "lifecycle", "set", "/v2x_ros_driver_node", "configure"],
-        )
-
-        # Wait for configured amount of time before attempting to transition to configured state
-        configuration_trigger = launch.actions.TimerAction(
-            period=float(configuration_delay),
-            actions=[process_configure]
-        )
-
-        # Event handler for activation
-        configured_event_handler = launch.actions.RegisterEventHandler(
-            launch.event_handlers.OnExecutionComplete(
-                target_action=process_configure,
-                on_completion=[
-                    launch.actions.ExecuteProcess(
-                        cmd=[ros2_cmd, "lifecycle", "set", "/v2x_ros_driver_node", "activate"],
-                    )
-                ]
-            )
-        )
-
-        return [ configuration_trigger, configured_event_handler]
-    else:
-        return []
 
 def generate_launch_description():
 
@@ -126,11 +84,41 @@ def generate_launch_description():
         on_exit= Shutdown()
     )
 
+    ros2_cmd = launch.substitutions.FindExecutable(name="ros2")
+
+    process_configure_v2x_ros_driver_node = launch.actions.ExecuteProcess(
+        condition=IfCondition(
+            PythonExpression(["'", enable_v2x_driver_lifecycle, "' == 'true'"])
+        ),
+        cmd=[
+            ros2_cmd, "lifecycle", "set", "/v2x_ros_driver_node", "configure",
+        ],
+    )
+
+    configured_event_handler_v2x_ros_driver_node = launch.actions.RegisterEventHandler(
+        launch.event_handlers.OnExecutionComplete(
+            target_action=process_configure_v2x_ros_driver_node,
+            on_completion=[
+                launch.actions.ExecuteProcess(
+                    cmd=[
+                        ros2_cmd, "lifecycle", "set", "/v2x_ros_driver_node", "activate",
+                    ],
+                )
+            ],
+        )
+    )
+
+    configuration_trigger = launch.actions.TimerAction(
+        period=configuration_delay,
+        actions=[process_configure_v2x_ros_driver_node],
+    )
+
 
     return LaunchDescription([
         declare_log_level_arg,
         declare_configuration_delay_arg,
         declare_enable_v2x_driver_lifecycle,
         container,
-        OpaqueFunction(function=launch_v2x_lifecycle, args=[enable_v2x_driver_lifecycle, configuration_delay]),
+        configuration_trigger,
+        configured_event_handler_v2x_ros_driver_node
     ])

--- a/v2x_ros_driver/launch/v2x_ros_driver.launch.py
+++ b/v2x_ros_driver/launch/v2x_ros_driver.launch.py
@@ -32,13 +32,13 @@ This file is can be used to launch the CARMA v2x_ros_driver_node.
   Though in carma-platform it may be launched directly from the base launch file.
 '''
 
-def launch_v2x_lifecycle(context: LaunchContext, enable_v2x_lifecycle_arg, configuration_delay_arg):
+def launch_v2x_lifecycle(context: LaunchContext, enable_v2x_driver_lifecycle_arg, configuration_delay_arg):
 
-    # Get enable_v2x_lifecycle launch argument
-    enable_v2x_lifecycle = context.perform_substitution(enable_v2x_lifecycle_arg)
+    # Get enable_v2x_driver_lifecycle launch argument
+    enable_v2x_driver_lifecycle = context.perform_substitution(enable_v2x_driver_lifecycle_arg)
 
     # Check if the lifecycle should be enabled
-    if enable_v2x_lifecycle == 'true':
+    if enable_v2x_driver_lifecycle == 'true':
         # Get the ROS2 executable
         ros2_cmd = context.perform_substitution( launch.substitutions.FindExecutable(name='ros2'))
 
@@ -82,9 +82,9 @@ def generate_launch_description():
     declare_configuration_delay_arg = DeclareLaunchArgument(
         name ='configuration_delay', default_value='2.0')
 
-    enable_v2x_lifecycle = LaunchConfiguration('enable_v2x_lifecycle')
-    declare_enable_v2x_lifecycle = DeclareLaunchArgument(
-        name ='enable_v2x_lifecycle', default_value='false')
+    enable_v2x_driver_lifecycle = LaunchConfiguration('enable_v2x_driver_lifecycle')
+    declare_enable_v2x_driver_lifecycle = DeclareLaunchArgument(
+        name ='enable_v2x_driver_lifecycle', default_value='true')
 
     # Get parameter file path
     param_file_path = os.path.join(
@@ -122,7 +122,7 @@ def generate_launch_description():
     return LaunchDescription([
         declare_log_level_arg,
         declare_configuration_delay_arg,
-        declare_enable_v2x_lifecycle,
+        declare_enable_v2x_driver_lifecycle,
         container,
-        OpaqueFunction(function=launch_v2x_lifecycle, args=[enable_v2x_lifecycle, configuration_delay]),
+        OpaqueFunction(function=launch_v2x_lifecycle, args=[enable_v2x_driver_lifecycle, configuration_delay]),
     ])

--- a/v2x_ros_driver/launch/v2x_ros_driver.launch.py
+++ b/v2x_ros_driver/launch/v2x_ros_driver.launch.py
@@ -25,6 +25,7 @@ from launch.substitutions import LaunchConfiguration
 from carma_ros2_utils.launch.get_current_namespace import GetCurrentNamespace
 from launch.conditions import IfCondition
 from launch.substitutions import PythonExpression
+from launch.actions import GroupAction
 
 import os
 
@@ -49,7 +50,7 @@ def generate_launch_description():
 
     enable_v2x_driver_lifecycle = LaunchConfiguration('enable_v2x_driver_lifecycle')
     declare_enable_v2x_driver_lifecycle = DeclareLaunchArgument(
-        name ='enable_v2x_driver_lifecycle', default_value='false',
+        name ='enable_v2x_driver_lifecycle', default_value='False',
         description="Enable the v2x_ros_driver_node lifecycle. If enabled manually transitions the node to active state. Default is false")
 
     # Get parameter file path
@@ -84,41 +85,43 @@ def generate_launch_description():
         on_exit= Shutdown()
     )
 
+    # Node lifecycle activation called only if enable_v2x_driver_lifecycle is set to true
     ros2_cmd = launch.substitutions.FindExecutable(name="ros2")
-
     process_configure_v2x_ros_driver_node = launch.actions.ExecuteProcess(
-        condition=IfCondition(
-            PythonExpression(["'", enable_v2x_driver_lifecycle, "' == 'true'"])
-        ),
         cmd=[
             ros2_cmd, "lifecycle", "set", "/v2x_ros_driver_node", "configure",
         ],
     )
 
-    configured_event_handler_v2x_ros_driver_node = launch.actions.RegisterEventHandler(
-        launch.event_handlers.OnExecutionComplete(
-            target_action=process_configure_v2x_ros_driver_node,
-            on_completion=[
-                launch.actions.ExecuteProcess(
-                    cmd=[
-                        ros2_cmd, "lifecycle", "set", "/v2x_ros_driver_node", "activate",
+    activate_node_group_action = GroupAction(
+        condition=IfCondition(LaunchConfiguration('enable_v2x_driver_lifecycle')),
+        actions=[
+            # Set node lifecycle to configure after a delay
+            launch.actions.TimerAction(
+                period=LaunchConfiguration('configuration_delay'),
+                actions=[process_configure_v2x_ros_driver_node],
+            ),
+
+            # Activate node after configuration
+            launch.actions.RegisterEventHandler(
+                launch.event_handlers.OnExecutionComplete(
+                    target_action=process_configure_v2x_ros_driver_node,
+                    on_completion=[
+                        launch.actions.ExecuteProcess(
+                            cmd=[
+                                ros2_cmd, "lifecycle", "set", "/v2x_ros_driver_node", "activate",
+                            ],
+                        )
                     ],
                 )
-            ],
-        )
+            ),
+        ]
     )
-
-    configuration_trigger = launch.actions.TimerAction(
-        period=configuration_delay,
-        actions=[process_configure_v2x_ros_driver_node],
-    )
-
 
     return LaunchDescription([
         declare_log_level_arg,
         declare_configuration_delay_arg,
         declare_enable_v2x_driver_lifecycle,
         container,
-        configuration_trigger,
-        configured_event_handler_v2x_ros_driver_node
+        activate_node_group_action
     ])

--- a/v2x_ros_driver/launch/v2x_ros_driver.launch.py
+++ b/v2x_ros_driver/launch/v2x_ros_driver.launch.py
@@ -85,7 +85,6 @@ def generate_launch_description():
         on_exit= Shutdown()
     )
 
-    # Node lifecycle activation called only if enable_v2x_driver_lifecycle is set to true
     ros2_cmd = launch.substitutions.FindExecutable(name="ros2")
     process_configure_v2x_ros_driver_node = launch.actions.ExecuteProcess(
         cmd=[
@@ -94,6 +93,7 @@ def generate_launch_description():
     )
 
     activate_node_group_action = GroupAction(
+        # Node lifecycle activation called only if enable_v2x_driver_lifecycle is set to true
         condition=IfCondition(LaunchConfiguration('enable_v2x_driver_lifecycle')),
         actions=[
             # Set node lifecycle to configure after a delay

--- a/v2x_ros_driver/launch/v2x_ros_driver.launch.py
+++ b/v2x_ros_driver/launch/v2x_ros_driver.launch.py
@@ -12,19 +12,17 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-from ament_index_python import get_package_share_directory
-from launch import LaunchDescription, LaunchContext
-from launch_ros.actions import ComposableNodeContainer
-from launch_ros.descriptions import ComposableNode
-from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration
-from launch.actions import Shutdown
 import launch.actions
 import launch.events
 import launch_ros.events.lifecycle
 import lifecycle_msgs.msg
+from ament_index_python import get_package_share_directory
+from launch import LaunchDescription, LaunchContext
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+from launch.actions import DeclareLaunchArgument, Shutdown, ExecuteProcess, OpaqueFunction
+from launch.substitutions import LaunchConfiguration
 from carma_ros2_utils.launch.get_current_namespace import GetCurrentNamespace
-from launch.actions import ExecuteProcess, OpaqueFunction
 
 import os
 
@@ -86,7 +84,7 @@ def generate_launch_description():
 
     enable_v2x_lifecycle = LaunchConfiguration('enable_v2x_lifecycle')
     declare_enable_v2x_lifecycle = DeclareLaunchArgument(
-        name ='enable_v2x_lifecycle', default_value='true')
+        name ='enable_v2x_lifecycle', default_value='false')
 
     # Get parameter file path
     param_file_path = os.path.join(

--- a/v2x_ros_driver/launch/v2x_ros_driver.launch.py
+++ b/v2x_ros_driver/launch/v2x_ros_driver.launch.py
@@ -32,7 +32,11 @@ This file is can be used to launch the CARMA v2x_ros_driver_node.
   Though in carma-platform it may be launched directly from the base launch file.
 '''
 
-def launch_v2x_lifecycle(context: LaunchContext, enable_v2x_driver_lifecycle_arg, configuration_delay_arg):
+'''
+This function is used to call the v2x_ros_driver_node lifecycle transitions.
+  It will configure the node and then activate it.
+'''
+def transition_v2x_driver_lifecycle(context: LaunchContext, enable_v2x_driver_lifecycle_arg, configuration_delay_arg):
 
     # Get enable_v2x_driver_lifecycle launch argument
     enable_v2x_driver_lifecycle = context.perform_substitution(enable_v2x_driver_lifecycle_arg)
@@ -50,7 +54,7 @@ def launch_v2x_lifecycle(context: LaunchContext, enable_v2x_driver_lifecycle_arg
             cmd=[ros2_cmd, "lifecycle", "set", "/v2x_ros_driver_node", "configure"],
         )
 
-        # Timer action
+        # Wait for configured amount of time before attempting to transition to configured state
         configuration_trigger = launch.actions.TimerAction(
             period=float(configuration_delay),
             actions=[process_configure]
@@ -69,22 +73,26 @@ def launch_v2x_lifecycle(context: LaunchContext, enable_v2x_driver_lifecycle_arg
         )
 
         return [ configuration_trigger, configured_event_handler]
-    return []
+    else:
+        return []
 
 def generate_launch_description():
 
     # Declare the log_level launch argument
     log_level = LaunchConfiguration('log_level')
     declare_log_level_arg = DeclareLaunchArgument(
-        name ='log_level', default_value='WARN')
+        name ='log_level', default_value='WARN',
+        description="The log level to use for the v2x_ros_driver_node")
 
     configuration_delay = LaunchConfiguration('configuration_delay')
     declare_configuration_delay_arg = DeclareLaunchArgument(
-        name ='configuration_delay', default_value='2.0')
+        name ='configuration_delay', default_value='2.0',
+        description="The delay in seconds before the v2x_ros_driver_node is configured")
 
     enable_v2x_driver_lifecycle = LaunchConfiguration('enable_v2x_driver_lifecycle')
     declare_enable_v2x_driver_lifecycle = DeclareLaunchArgument(
-        name ='enable_v2x_driver_lifecycle', default_value='true')
+        name ='enable_v2x_driver_lifecycle', default_value='false',
+        description="Enable the v2x_ros_driver_node lifecycle. If enabled manually transitions the node to active state. Default is false")
 
     # Get parameter file path
     param_file_path = os.path.join(


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
Fixes launch file for v2x-ros-driver and adds optional flag to enable lifecycle transition for v2x-ros-driver.
This change is required to allow users not using a lifecycle manager to be able to transition the node to active state directly from the launch file.
In the CARMA ecosystem this driver is used with carma-platform which defines a lifecycle manager for the node. Having a lifecycle manager is recommended to be able to gracefully activate, track failures and gracefully shutdown the node, but adding the optional argument allows users to use the driver in the absence of one as well.

## Description

<!--- Describe your changes in detail -->
This change set was tested locally using just the launch file for the v2x_ros_driver node as well as on the Black Pacifica calling the v2x-ros-driver node to launch through carma-platform's launch system. 
The node lifecycle was confirmed to be "active" when the enable_v2x_driver_lifecycle argument was set to true and "unconfigured" with it set to false.

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->
https://usdot-carma.atlassian.net/browse/ARC-178

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
