### PR TITLE
Add security argument to MK6 OBU setup script

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,8 @@
 The Cohda MK6 OBU can be configured using the [mk6-rsu-obu-setup.sh](mk6-rsu-obu-setup.sh) script.
 We have observed occasional clearing of the configuration, so a separate script will be run to ensure the configurations exist.
 
+Additionally, SecurityEnable is defaulted to 0 (disabled). To enable security (signed messages), manually run [mk6-rsu-obu-setup.sh](mk6-rsu-obu-setup.sh) with 1 as an argument.
+
 **Note**: This driver assumes the OBU IPv4 address is set to: 192.168.88.40/24.
 
 
@@ -38,9 +40,9 @@ cp /tmp/rc.local /mnt/rw/
 chmod +x /mnt/rw/*.sh
 chmod +x /mnt/rw/rc.local
 ```
-8.	Run the setup script:
+8.	Run the setup script (with security disabled):
 ```
-/mnt/rw/mk6-rsu-obu-setup.sh
+/mnt/rw/mk6-rsu-obu-setup.sh 0
 ```
 9.	Reboot the OBU after the script is done executing:
 ```

--- a/docs/check-mk6-conf.sh
+++ b/docs/check-mk6-conf.sh
@@ -141,7 +141,8 @@ echo "Summary: $PASSED passed, $FAILED failed"
 if [ $FAILED -ne 0 ]; then
     echo "Some SNMP table values did not match the expected configuration."
     echo "Running mk6-rsu-obu-setup.sh to reconfigure..."
-    /mnt/rw/mk6-rsu-obu-setup.sh
+    echo "Defaulting to SecurityEnable = 0"
+    /mnt/rw/mk6-rsu-obu-setup.sh 0
     
     exit 1
 else

--- a/docs/mk6-rsu-obu-setup.sh
+++ b/docs/mk6-rsu-obu-setup.sh
@@ -115,6 +115,8 @@ if [[ $HOSTNAME =~ MK[5-6] ]]; then
 fi
 }
 
+# Function to read a valid input for SecurityEnable
+# It will keep prompting until a valid input (0 or 1) is provided
 read_valid() {
     local val
     while :; do
@@ -290,7 +292,7 @@ echo " "
 _configure_IFM_simulation
 _detect_host
 
-# If $1 provided, validate it; otherwise prompt.
+# If $1 provided, validate it; otherwise prompt. An argument of 0 or 1 for SecurityEnabled (disabled/enabled, respectively) is expected.
 if [[ $# -gt 0 ]]; then
     case "$1" in
         0|1) input="$1" ;;

--- a/docs/mk6-rsu-obu-setup.sh
+++ b/docs/mk6-rsu-obu-setup.sh
@@ -50,6 +50,8 @@ sed -i '0,/board/I!d' /mnt/rw/rsu1609/conf/stack.conf
 echo " " >> /mnt/rw/rsu1609/conf/stack.conf
 sync
 
+echo "Using user input: SecurityEnable = $1"
+
 if [[ $HOSTNAME =~ MK5 ]]; then
   echo "TxALogEnableFlag           = 1"     >> /mnt/rw/rsu1609/conf/stack.conf
   echo "RxALogEnableFlag           = 1"     >> /mnt/rw/rsu1609/conf/stack.conf
@@ -73,7 +75,7 @@ fi
   echo "Cohda_DebugTimeLevel       = 1"     >> /mnt/rw/rsu1609/conf/stack.conf
   echo "Cohda_DebugInfoLevel       = 2"     >> /mnt/rw/rsu1609/conf/stack.conf
 
-  echo "SecurityEnable             = 1"     >> /mnt/rw/rsu1609/conf/stack.conf
+  echo "SecurityEnable             = $1"     >> /mnt/rw/rsu1609/conf/stack.conf
 
   echo "Cohda_Crypto_TestCountryCode = 840" >> /mnt/rw/rsu1609/conf/stack.conf
   echo "Cohda_Crypto_AeroLogging     = all" >> /mnt/rw/rsu1609/conf/stack.conf
@@ -102,7 +104,7 @@ if [[ $HOSTNAME =~ MK[5-6] ]]; then
   sync
   net-snmp-config --create-snmpv3-user -A $PW0 -X $PW0 -a SHA -x AES $ID0 
 
-  _edit_stack_conf
+  _edit_stack_conf $1
   rm -rf /mnt/rw/rsu1609/conf/user.conf 
   sync
 
@@ -113,6 +115,16 @@ if [[ $HOSTNAME =~ MK[5-6] ]]; then
 fi
 }
 
+read_valid() {
+    local val
+    while :; do
+        read -rp "Enter SecurityEnable (0 or 1) i.e., disabled=0, enabled=1: " val
+        case "$val" in
+            0|1) printf '%s' "$val"; return 0 ;;
+            *)   printf 'Invalid. Try again.\n' >&2 ;;
+        esac
+    done
+}
 
 ##############################################################################
 # Helper Functions
@@ -277,7 +289,18 @@ _set_IFM() {
 echo " "
 _configure_IFM_simulation
 _detect_host
-_manually_manipulate_rsu_files
+
+# If $1 provided, validate it; otherwise prompt.
+if [[ $# -gt 0 ]]; then
+    case "$1" in
+        0|1) input="$1" ;;
+        *)   printf 'Error: arg must be 0 or 1\n' >&2; exit 1 ;;
+    esac
+else
+    input="$(read_valid)"
+fi
+
+_manually_manipulate_rsu_files "$input"
 _SYNC
 
 _set_standby


### PR DESCRIPTION
	modified:   docs/check-mk6-conf.sh
	modified:   docs/mk6-rsu-obu-setup.sh

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

These changes allow users to enable/disable security when running the setup script. Documentation has been updated to assist the user, with security disabled set as the default. 

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

CAR-6139

## Motivation and Context

The setup script was defaulted to security enabled, however security is disabled in most cases. This allows a user who knows about security to enable it. 

## How Has This Been Tested?

Tested with an MK6 OBU.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
