### PR TITLE
Updated publisher to convert hex string from wave.json to decimal

### DIFF
--- a/v2x_ros_driver/src/mqtt_radio_client.cpp
+++ b/v2x_ros_driver/src/mqtt_radio_client.cpp
@@ -275,18 +275,20 @@ void MqttRadioClient::subscribeToTopics()
     }
 }
 
-std::string MqttRadioClient::buildPublishTopic(const std::string &psid_hex) const
-{
-    // Strip leading zeros from PSID hex for topic
-    std::string stripped = psid_hex;
-    size_t start = stripped.find_first_not_of('0');
-    if (start != std::string::npos)
-        stripped = stripped.substr(start);
-    else
-        stripped = "0";
+// Override map — only for PSID where Ettifos differs from current wave.json mapping (SDSM)
+static const std::unordered_map<std::string, int> kEttifosPsidOverrides = {
+    {"8010", 144},  // SDSM: Ettifos=0x90
+};
 
-    // Ettifos/V2X/req/J2735/{PSID}
-    return mqtt_topic_prefix_ + "/req/J2735/" + stripped;
+std::string MqttRadioClient::buildPublishTopic(const std::string &psid_hex) const {
+    int decimal_psid;
+    auto it = kEttifosPsidOverrides.find(psid_hex);
+    if (it != kEttifosPsidOverrides.end()) {
+        decimal_psid = it->second;
+    } else {
+        decimal_psid = std::stoi(psid_hex, nullptr, 16);
+    }
+    return mqtt_topic_prefix_ + "/req/J2735/" + std::to_string(decimal_psid);
 }
 
 std::string MqttRadioClient::buildSubscribeTopic() const


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

The current implementation of the MQTT support in the v2x-ros-driver does not convert the HEX PSIDs from the wave.json file when attempting to publish messages. This change converts the PSID (which is selected from the matching DSRC message ID based on message type) from hex to the decimal value, which the Ettifos OBU uses.

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

Fixes publishing on the v2x-ros-driver for the Ettifos OBU

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
