### PR TITLE
update messages PSID for ettifos

### DIFF
--- a/v2x_ros_driver/src/mqtt_radio_client.cpp
+++ b/v2x_ros_driver/src/mqtt_radio_client.cpp
@@ -286,8 +286,6 @@ static const std::unordered_map<std::string, int> kEttifosPsidOverrides = {
     {"0027", 39},  //PSM
     /* Test Messages */
     {"BFEE", 49134},  //Mobility Messages
-    {"8003", 49134}, //TCR and TCM
-    {"8005",49134},  //Emergency Vehicle Ack and Response
     //TODO for future: SRM ID: 2113686
 };
 

--- a/v2x_ros_driver/src/mqtt_radio_client.cpp
+++ b/v2x_ros_driver/src/mqtt_radio_client.cpp
@@ -275,9 +275,20 @@ void MqttRadioClient::subscribeToTopics()
     }
 }
 
-// Override map — only for PSID where Ettifos differs from current wave.json mapping (SDSM)
+// Override map — only for PSID where Ettifos differs from current wave.json mapping
 static const std::unordered_map<std::string, int> kEttifosPsidOverrides = {
-    {"8010", 144},  // SDSM: Ettifos=0x90
+
+    {"0020", 32},  // BSM
+    {"0083", 131},  // TIM
+    {"0082", 2113687},  // MAP
+    {"0082", 130},  //SPAT
+    {"8010", 144},  //SDSM
+    {"0027", 39},  //PSM
+    /* Test Messages */
+    {"BFEE", 49134},  //Mobility Messages
+    {"8003", 49134}, //TCR and TCM
+    {"8005",49134},  //Emergency Vehicle Ack and Response
+    //TODO for future: SRM ID: 2113686
 };
 
 std::string MqttRadioClient::buildPublishTopic(const std::string &psid_hex) const {

--- a/v2x_ros_driver/src/mqtt_radio_client.cpp
+++ b/v2x_ros_driver/src/mqtt_radio_client.cpp
@@ -285,7 +285,7 @@ static const std::unordered_map<std::string, int> kEttifosPsidOverrides = {
     {"8010", 144},  //SDSM
     {"0027", 39},  //PSM
     /* Test Messages */
-    {"BFEE", 49134},  //Mobility Messages
+    {"BFEE", 16494},  //Mobility Messages
     //TODO for future: SRM ID: 2113686
 };
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

In this PR, the ettifos PSID overwrite function is updated for all the messages that have a different PSID from the udp wave.json file.

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

https://usdot-carma.atlassian.net/browse/CSE-14
https://usdot-carma.atlassian.net/browse/CSE-52

## Motivation and Context

The mqtt protocol has a different PSID for most messages than the udp protocol. An overwrite function is added to use the correct message ID.

## How Has This Been Tested?
Tested locally (NUC + Ettifos OBU)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
